### PR TITLE
Update WebSocket to remove npm audit vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "author": "Eric Oestrich <eric@oestrich.org>",
   "license": "MIT",
   "dependencies": {
-    "ws": "^3.1.0"
+    "ws": "^6.1.2"
   }
 }


### PR DESCRIPTION
I noticed while working on this bundle that it was throwing an `npm audit` warning due to the WebSocket version.